### PR TITLE
Allow overriding the nameserver setting for cloudflared tunnels

### DIFF
--- a/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
+++ b/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 _TUNNEL_TOKEN_SECRET_ID_FIELD = "tunnel_token_secret_id"
 _TUNNEL_TOKEN_SECRET_VALUE_FIELD = "tunnel-token"
@@ -150,7 +150,7 @@ class CloudflaredRouteRequirer:
             ) from exc
 
     def get_nameserver(self, relation: ops.Relation) -> str | None:
-        """the nameserver used by the Cloudflared tunnel.
+        """Get the nameserver used by the Cloudflared tunnel.
 
         Args:
             relation: relation to receive the tunnel-token from.

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,6 @@
 
 """Cloudflared charm service."""
 
-import collections
 import logging
 import pathlib
 import subprocess  # nosec
@@ -33,7 +32,16 @@ class InvalidConfig(ValueError):
     """Charm received invalid configurations."""
 
 
-CloudflaredSpec = collections.namedtuple("CloudflaredSpec", "tunnel_token nameserver")
+class CloudflaredSpec(typing.NamedTuple):
+    """Cloudflared tunnel configuration.
+
+    Attributes:
+        tunnel_token: cloudflared tunnel token.
+        nameserver: nameserver used by the cloudflared tunnel.
+    """
+
+    tunnel_token: str
+    nameserver: str | None
 
 
 class CloudflaredCharm(ops.CharmBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,7 @@ class CloudflaredCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def _update_cloudflared_resolv_conf(self, name: str, nameserver: str | None) -> None:
-        """Updates the resolv.conf file for the specified charmed-cloudflared snap instance.
+        """Update the resolv.conf file for the specified charmed-cloudflared snap instance.
 
         Args:
             name: The name of the charmed-cloudflared snap instance.

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,7 @@ class CloudflaredCharm(ops.CharmBase):
                     "./src/charmed-cloudflared_2024.9.1_amd64.snap.zip",
                     "--name",
                     install_instance,
-                    "--dangerous"
+                    "--dangerous",
                 ]
             )
         for instance, tunnel_spec in tunnel_specs.items():

--- a/src/charm.py
+++ b/src/charm.py
@@ -100,10 +100,8 @@ class CloudflaredCharm(ops.CharmBase):
                 [
                     "snap",
                     "install",
-                    "./src/charmed-cloudflared_2024.9.1_amd64.snap.zip",
-                    "--name",
+                    CHARMED_CLOUDFLARED_SNAP_NAME,
                     install_instance,
-                    "--dangerous",
                 ]
             )
         for instance, tunnel_spec in tunnel_specs.items():

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,6 +95,7 @@ class CloudflaredCharm(ops.CharmBase):
                     "./src/charmed-cloudflared_2024.9.1_amd64.snap.zip",
                     "--name",
                     install_instance,
+                    "--dangerous"
                 ]
             )
         for instance, tunnel_spec in tunnel_specs.items():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -188,8 +188,10 @@ SRC_OVERWRITE = json.dumps(
 )
 
 
-@pytest_asyncio.fixture(scope="module")
-async def cloudflared_route_provider_1(model, cloudflared_charm) -> juju.application.Application:
+@pytest_asyncio.fixture(name="cloudflared_route_provider_1", scope="module")
+async def cloudflared_route_provider_1_fixture(
+    model, cloudflared_charm
+) -> juju.application.Application:
     """Deploy a cloudflared-route requirer using any-charm."""
     charm = await model.deploy(
         "any-charm",
@@ -203,8 +205,8 @@ async def cloudflared_route_provider_1(model, cloudflared_charm) -> juju.applica
     return charm
 
 
-@pytest_asyncio.fixture(scope="module")
-async def cloudflared_route_provider_2(model) -> juju.application.Application:
+@pytest_asyncio.fixture(name="cloudflared_route_provider_2", scope="module")
+async def cloudflared_route_provider_2_fixture(model) -> juju.application.Application:
     """Deploy a cloudflared-route requirer using any-charm."""
     charm = await model.deploy(
         "any-charm",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -147,8 +147,10 @@ def model_fixture(ops_test) -> juju.model.Model:
     return ops_test.model
 
 
-@pytest_asyncio.fixture(scope="module")
-async def cloudflared_charm(model, pytestconfig: pytest.Config) -> juju.application.Application:
+@pytest_asyncio.fixture(name="cloudflared_charm", scope="module")
+async def cloudflared_charm_fixture(
+    model, pytestconfig: pytest.Config
+) -> juju.application.Application:
     """Deploy the cloudflared charm."""
     charm = pytestconfig.getoption("--charm-file")
     return await model.deploy(f"./{charm}", num_units=0)
@@ -206,7 +208,9 @@ async def cloudflared_route_provider_1_fixture(
 
 
 @pytest_asyncio.fixture(name="cloudflared_route_provider_2", scope="module")
-async def cloudflared_route_provider_2_fixture(model) -> juju.application.Application:
+async def cloudflared_route_provider_2_fixture(
+    model, cloudflared_charm
+) -> juju.application.Application:
     """Deploy a cloudflared-route requirer using any-charm."""
     charm = await model.deploy(
         "any-charm",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -189,9 +189,9 @@ SRC_OVERWRITE = json.dumps(
 
 
 @pytest_asyncio.fixture(scope="module")
-async def cloudflared_route_provider_1(model) -> juju.application.Application:
+async def cloudflared_route_provider_1(model, cloudflared_charm) -> juju.application.Application:
     """Deploy a cloudflared-route requirer using any-charm."""
-    return await model.deploy(
+    charm = await model.deploy(
         "any-charm",
         "cloudflared-route-provider-one",
         config={
@@ -199,12 +199,14 @@ async def cloudflared_route_provider_1(model) -> juju.application.Application:
         },
         channel="latest/edge",
     )
+    await model.integrate(f"{cloudflared_charm.name}:cloudflared-route", charm.name)
+    return charm
 
 
 @pytest_asyncio.fixture(scope="module")
 async def cloudflared_route_provider_2(model) -> juju.application.Application:
     """Deploy a cloudflared-route requirer using any-charm."""
-    return await model.deploy(
+    charm = await model.deploy(
         "any-charm",
         "cloudflared-route-provider-two",
         config={
@@ -212,6 +214,8 @@ async def cloudflared_route_provider_2(model) -> juju.application.Application:
         },
         channel="latest/edge",
     )
+    await model.integrate(f"{cloudflared_charm.name}:cloudflared-route", charm.name)
+    return charm
 
 
 @pytest_asyncio.fixture(name="dnsmasq", scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -268,8 +268,8 @@ async def dnsmasq_fixture(ops_test, model) -> juju.application.Application:
 
 @pytest_asyncio.fixture(scope="module")
 async def dnsmasq_ip(ops_test, dnsmasq) -> str:
+    """Get the IP address of dnsmasq."""
     _, status, _ = await ops_test.juju("status", "--format", "json")
     status = json.loads(status)
     units = status["applications"][dnsmasq.name]["units"]
-    for unit in units.values():
-        return unit["public-address"]
+    return list(units.values())[0]["public-address"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -173,10 +173,10 @@ SRC_OVERWRITE = json.dumps(
 
                 def set_tunnel_token(self, tunnel_token):
                     return self.cloudflared_route.set_tunnel_token(tunnel_token)
-                
+
                 def unset_tunnel_token(self):
                     self.cloudflared_route.unset_tunnel_token()
-                    
+
                 def set_nameserver(self, nameserver):
                     return self.cloudflared_route.set_nameserver(nameserver)
             """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -267,6 +267,15 @@ async def dnsmasq_fixture(ops_test, model) -> juju.application.Application:
         "-c",
         "echo log-facility=/var/log/dnsmasq.log >> /etc/dnsmasq.conf",
     )
+    await ops_test.juju(
+        "exec",
+        "--application",
+        dnsmasq.name,
+        "--",
+        "systemctl",
+        "restart",
+        "dnsmasq",
+    )
     return dnsmasq
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -272,4 +272,4 @@ async def dnsmasq_ip(ops_test, dnsmasq) -> str:
     status = json.loads(status)
     units = status["applications"][dnsmasq.name]["units"]
     for unit in units.values():
-        return unit["address"]
+        return unit["public-address"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -73,12 +73,6 @@ async def test_cloudflared_route_integration(
     assume: cloudflared tunnels provided in the integration is up and healthy.
     """
     await cloudflared_charm.set_config({"tunnel-token": ""})
-    await model.integrate(
-        f"{cloudflared_charm.name}:cloudflared-route", cloudflared_route_provider_1.name
-    )
-    await model.integrate(
-        f"{cloudflared_charm.name}:cloudflared-route", cloudflared_route_provider_2.name
-    )
     await model.wait_for_idle()
     tunnel_token_1 = cloudflare_api.create_tunnel_token()
     tunnel_token_2 = cloudflare_api.create_tunnel_token()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -114,12 +114,6 @@ async def test_nameserver(
     assume: cloudflared tunnels should use the given nameserver.
     """
     await cloudflared_charm.set_config({"tunnel-token": ""})
-    await model.integrate(
-        f"{cloudflared_charm.name}:cloudflared-route", cloudflared_route_provider_1.name
-    )
-    await model.integrate(
-        f"{cloudflared_charm.name}:cloudflared-route", cloudflared_route_provider_2.name
-    )
     await model.wait_for_idle()
     tunnel_token = cloudflare_api.create_tunnel_token()
     logger.info("use dnsmasq nameserver: %s", dnsmasq_ip)


### PR DESCRIPTION
### Overview

Allow overriding the nameserver setting for cloudflared tunnels

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
