### PR TITLE
Improve user experience

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -93,11 +93,11 @@ class CloudflaredCharm(ops.CharmBase):
             logger.exception("charm received invalid configuration")
             self.unit.status = ops.BlockedStatus(str(exc))
             return
-        installed_charmed_cloudflared = self._get_installed_cloudflared_snaps()
         required_snap_instances = set(metrics_ports.keys())
         if not required_snap_instances:
             self.unit.status = ops.WaitingStatus("waiting for tunnel token")
             return
+        installed_charmed_cloudflared = self._get_installed_cloudflared_snaps()
         for remove_instance in installed_charmed_cloudflared - required_snap_instances:
             logger.info("removing charmed-cloudflared instance: %s", remove_instance)
             snap.remove(remove_instance)

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,6 +58,10 @@ class CloudflaredCharm(ops.CharmBase):
         self.framework.observe(self.on.config_changed, self._reconcile)
         self.framework.observe(self.on.secret_changed, self._reconcile)
         self.framework.observe(self.on["cloudflared-route"].relation_changed, self._reconcile)
+        self.framework.observe(self.on["cloudflared-route"].relation_departed, self._reconcile)
+        self.framework.observe(self.on["juju-info"].relation_changed, self._reconcile)
+        self.framework.observe(self.on["juju-info"].relation_departed, self._reconcile)
+        self.framework.observe(self.on.stop, self._on_stop)
         self._snap_client = snap.SnapClient()
         self._cloudflared_route = CloudflaredRouteRequirer(self)
         self._grafana_agent = COSAgentProvider(
@@ -75,6 +79,11 @@ class CloudflaredCharm(ops.CharmBase):
         # pylint: disable=protected-access
         snap._system_set("experimental.parallel-instances", "true")
 
+    def _on_stop(self, _: ops.EventBase) -> None:
+        """Handle the stop event."""
+        for instance in self._get_installed_cloudflared_snaps():
+            snap.remove(instance)
+
     def _reconcile(self, _: ops.EventBase) -> None:
         """Handle changed configuration."""
         try:
@@ -84,11 +93,10 @@ class CloudflaredCharm(ops.CharmBase):
             logger.exception("charm received invalid configuration")
             self.unit.status = ops.BlockedStatus(str(exc))
             return
-        installed_charmed_cloudflared = set()
-        installed_snaps = self._snap_client.get_installed_snaps()
-        for installed_snap in installed_snaps:
-            if installed_snap["name"].startswith(CHARMED_CLOUDFLARED_SNAP_NAME):
-                installed_charmed_cloudflared.add(installed_snap["name"])
+        if not metrics_ports:
+            self.unit.status = ops.WaitingStatus("waiting for tunnel token")
+            return
+        installed_charmed_cloudflared = self._get_installed_cloudflared_snaps()
         required_snap_instances = set(metrics_ports.keys())
         for remove_instance in installed_charmed_cloudflared - required_snap_instances:
             logger.info("removing charmed-cloudflared instance: %s", remove_instance)
@@ -116,6 +124,19 @@ class CloudflaredCharm(ops.CharmBase):
             logger.info("configuring charmed-cloudflared instance: %s", instance)
             charmed_cloudflared.set(config, typed=True)
         self.unit.status = ops.ActiveStatus()
+
+    def _get_installed_cloudflared_snaps(self) -> set[str]:
+        """Get installed charmed-cloudflared snap instances.
+
+        Returns:
+            the names of the installed charmed-cloudflared snap instances.
+        """
+        installed_charmed_cloudflared = set()
+        installed_snaps = self._snap_client.get_installed_snaps()
+        for installed_snap in installed_snaps:
+            if installed_snap["name"].startswith(CHARMED_CLOUDFLARED_SNAP_NAME):
+                installed_charmed_cloudflared.add(installed_snap["name"])
+        return installed_charmed_cloudflared
 
     def _update_cloudflared_resolv_conf(self, name: str, nameserver: str | None) -> None:
         """Update the resolv.conf file for the specified charmed-cloudflared snap instance.
@@ -159,7 +180,7 @@ class CloudflaredCharm(ops.CharmBase):
                         nameserver=None,
                     )
                 }
-            except (ops.SecretNotFoundError, ops.ModelError, KeyError) as exc:
+            except (ops.SecretNotFoundError, KeyError) as exc:
                 raise InvalidConfig("invalid tunnel-token config") from exc
         tunnel_tokens = {}
         for relation in relations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,11 +93,11 @@ class CloudflaredCharm(ops.CharmBase):
             logger.exception("charm received invalid configuration")
             self.unit.status = ops.BlockedStatus(str(exc))
             return
-        if not metrics_ports:
-            self.unit.status = ops.WaitingStatus("waiting for tunnel token")
-            return
         installed_charmed_cloudflared = self._get_installed_cloudflared_snaps()
         required_snap_instances = set(metrics_ports.keys())
+        if not required_snap_instances:
+            self.unit.status = ops.WaitingStatus("waiting for tunnel token")
+            return
         for remove_instance in installed_charmed_cloudflared - required_snap_instances:
             logger.info("removing charmed-cloudflared instance: %s", remove_instance)
             snap.remove(remove_instance)

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,6 +123,9 @@ class CloudflaredCharm(ops.CharmBase):
                 continue
             logger.info("configuring charmed-cloudflared instance: %s", instance)
             charmed_cloudflared.set(config, typed=True)
+            # work around the snap restart problem
+            charmed_cloudflared.stop()
+            charmed_cloudflared.start(enable=True)
         self.unit.status = ops.ActiveStatus()
 
     def _get_installed_cloudflared_snaps(self) -> set[str]:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -139,14 +139,14 @@ async def test_remove(ops_test, model, cloudflared_charm):
     assume: cloudflared charm should uninstall all charmed-cloudflared snap instances.
     """
     _, snap_list, _ = await ops_test.juju(
-        "exec", "--unit", "chrony/0", "--", "cat", "/var/log/dnsmasq.log"
+        "exec", "--unit", "chrony/0", "--", "snap", "list"
     )
     assert "charmed-cloudflared_" in snap_list
     logger.info("snap list before removal: %s", snap_list)
     await ops_test.juju("remove-relation", cloudflared_charm.name, "chrony")
     await model.wait_for_idle()
     _, snap_list, _ = await ops_test.juju(
-        "exec", "--unit", "chrony/0", "--", "cat", "/var/log/dnsmasq.log"
+        "exec", "--unit", "chrony/0", "--", "snap", "list"
     )
     assert "charmed-cloudflared_" not in snap_list
     logger.info("snap list after removal: %s", snap_list)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -138,15 +138,11 @@ async def test_remove(ops_test, model, cloudflared_charm):
     act: remove the cloudflared charm.
     assume: cloudflared charm should uninstall all charmed-cloudflared snap instances.
     """
-    _, snap_list, _ = await ops_test.juju(
-        "exec", "--unit", "chrony/0", "--", "snap", "list"
-    )
+    _, snap_list, _ = await ops_test.juju("exec", "--unit", "chrony/0", "--", "snap", "list")
     assert "charmed-cloudflared_" in snap_list
     logger.info("snap list before removal: %s", snap_list)
     await ops_test.juju("remove-relation", cloudflared_charm.name, "chrony")
-    await model.wait_for_idle()
-    _, snap_list, _ = await ops_test.juju(
-        "exec", "--unit", "chrony/0", "--", "snap", "list"
-    )
+    await model.wait_for_idle(apps=[cloudflared_charm.name], wait_for_exact_units=0)
+    _, snap_list, _ = await ops_test.juju("exec", "--unit", "chrony/0", "--", "snap", "list")
     assert "charmed-cloudflared_" not in snap_list
     logger.info("snap list after removal: %s", snap_list)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -142,10 +142,11 @@ async def test_remove(ops_test, model, cloudflared_charm):
         "exec", "--unit", "chrony/0", "--", "cat", "/var/log/dnsmasq.log"
     )
     assert "charmed-cloudflared_" in snap_list
-    logger.info("snap list: %s", snap_list)
+    logger.info("snap list before removal: %s", snap_list)
     await ops_test.juju("remove-relation", cloudflared_charm.name, "chrony")
     await model.wait_for_idle()
     _, snap_list, _ = await ops_test.juju(
         "exec", "--unit", "chrony/0", "--", "cat", "/var/log/dnsmasq.log"
     )
     assert "charmed-cloudflared_" not in snap_list
+    logger.info("snap list after removal: %s", snap_list)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -149,14 +149,22 @@ async def test_remove(ops_test, model, cloudflared_charm):
     await model.integrate("chrony", cloudflared_charm.name)
 
 
-async def test_secret_config_permission(ops_test, model, cloudflared_charm):
+async def test_secret_config_permission(
+    ops_test, model, cloudflared_charm, cloudflared_route_provider_1, cloudflared_route_provider_2
+):
     """
     arrange: create a tunnel token juju secret without granting the secret access to the charm.
     act: configure the charm with the incorrect juju secret.
     assume: cloudflared charm should enter error state.
     """
+    await ops_test.juju(
+        "remove-relation", cloudflared_charm.name, cloudflared_route_provider_1.name
+    )
+    await ops_test.juju(
+        "remove-relation", cloudflared_charm.name, cloudflared_route_provider_2.name
+    )
     _, secret_id, _ = await ops_test.juju(
-        "add-secret", "error-tunnel-token", f"tunnel-token=foobar"
+        "add-secret", "error-tunnel-token", "tunnel-token=foobar"
     )
     secret_id = secret_id.strip()
     await cloudflared_charm.set_config({"tunnel-token": secret_id})

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -146,3 +146,21 @@ async def test_remove(ops_test, model, cloudflared_charm):
     _, snap_list, _ = await ops_test.juju("exec", "--unit", "chrony/0", "--", "snap", "list")
     assert "charmed-cloudflared_" not in snap_list
     logger.info("snap list after removal: %s", snap_list)
+    await model.integrate("chrony", cloudflared_charm.name)
+
+
+async def test_secret_config_permission(ops_test, model, cloudflared_charm):
+    """
+    arrange: create a tunnel token juju secret without granting the secret access to the charm.
+    act: configure the charm with the incorrect juju secret.
+    assume: cloudflared charm should enter error state.
+    """
+    _, secret_id, _ = await ops_test.juju(
+        "add-secret", "error-tunnel-token", f"tunnel-token=foobar"
+    )
+    secret_id = secret_id.strip()
+    await cloudflared_charm.set_config({"tunnel-token": secret_id})
+    await model.wait_for_idle(raise_on_error=False)
+    _, juju_status, _ = await ops_test.juju("status")
+    logger.info("current juju status: %s", juju_status)
+    assert "error" in juju_status

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,6 +28,17 @@ def test_install(monkeypatch):
     magic_mock.assert_called_once_with("experimental.parallel-instances", "true")
 
 
+def test_initial_state():
+    """
+    arrange: none.
+    act: run config-changed event without any tunnel-token input.
+    assert: charm should enter the waiting state.
+    """
+    context = ops.testing.Context(CloudflaredCharm)
+    out = context.run(context.on.config_changed(), ops.testing.State())
+    assert out.unit_status == ops.WaitingStatus("waiting for tunnel token")
+
+
 def test_conflict_config_integration():
     """
     arrange: create a scenario with cloudflared-router integrations and tunnel-token config at the


### PR DESCRIPTION
### Overview

User Experience Improvements includes:
- The charm now enters error state (instead of a blocking state) when there is a permission error in the configuration.
- On initial deployment, the charm now enters the waiting state while it awaits the tunnel-token configuration.
- When the charm is removed, it will automatically clean up all instances of the `charmed-cloudflared` snap.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
