### PR TITLE
Add a charm config to select the charmed-cloudflared snap channel

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@secret-env
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       charmcraft-channel: latest/edge

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,7 +29,11 @@ config:
         You can create this juju secret by using the following command:
         `juju add-secret my-token tunnel-token=<cloudflared-tunnel-token> && juju grant-secret my-token cloudflared`
       type: secret
-
+    charmed-cloudflared-snap-channel:
+      type: string
+      default: latest/stable
+      description: >-
+        Select the channel for the charmed-cloudflared snap used by the charm.
 requires:
   cloudflared-route:
     interface: cloudflared-route

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 lazydocs --no-watermark --output-path src-docs src/*

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more at: https://juju.is/docs/sdk

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,15 +113,15 @@ class CloudflaredCharm(ops.CharmBase):
                     install_instance,
                 ]
             )
+        for instance, tunnel_spec in tunnel_specs.items():
             subprocess.check_call(  # nosec
                 [
                     "snap",
                     "refresh",
                     f"--channel={snap_channel}",
-                    install_instance,
+                    instance,
                 ]
             )
-        for instance, tunnel_spec in tunnel_specs.items():
             charmed_cloudflared = snap.SnapCache()[instance]
             self._update_ca_certificate_crt(instance)
             self._update_cloudflared_resolv_conf(instance, tunnel_spec.nameserver)

--- a/src/charm.py
+++ b/src/charm.py
@@ -157,7 +157,7 @@ class CloudflaredCharm(ops.CharmBase):
         Args:
             name: The name of the charmed-cloudflared snap instance.
         """
-        ca_certificates = pathlib.Path("/ssl/certs/ca-certificates.crt")
+        ca_certificates = pathlib.Path("/etc/ssl/certs/ca-certificates.crt")
         ca_certificates_content = ca_certificates.read_bytes()
         snap_ca_certificates = pathlib.Path(
             f"/var/snap/{name}/current/etc/ssl/certs/ca-certificates.crt"

--- a/src/charm.py
+++ b/src/charm.py
@@ -168,7 +168,9 @@ class CloudflaredCharm(ops.CharmBase):
         ):
             snap_ca_certificates.parent.mkdir(parents=True, exist_ok=True)
             snap_ca_certificates.write_bytes(ca_certificates_content)
-            snap_ca_certificates.chmod(0o444)
+            snap_ca_certificates.chmod(0o444)  # ca-certificates.crt
+            snap_ca_certificates.parent.chmod(0o555)  # certs/
+            snap_ca_certificates.parent.parent.chmod(0o555)  # ssl/
 
     def _update_cloudflared_resolv_conf(self, name: str, nameserver: str | None) -> None:
         """Update the resolv.conf file for the specified charmed-cloudflared snap instance.
@@ -187,6 +189,7 @@ class CloudflaredCharm(ops.CharmBase):
             or current_resolv_conf.read_text(encoding="utf-8") != resolv_conf
         ):
             current_resolv_conf.write_text(resolv_conf, encoding="utf-8")
+            current_resolv_conf.chmod(0o444)
 
     def _get_instance_tunnel_specs(self) -> dict[str, CloudflaredSpec]:
         """Get cloudflared configurations for all charmed-cloudflared snap instances.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm tests."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # pylint: disable=protected-access

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # pylint: disable=protected-access,too-many-arguments,too-many-positional-arguments

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -98,7 +98,7 @@ async def test_update_snap_channel(ops_test, model, cloudflared_charm):
     act: update the charmed-cloudflared-snap-channel charm configuration.
     assume: cloudflared charm should refresh all charmed-cloudflared snap instances.
     """
-    await cloudflared_charm.set_config({"charmed-cloudflared-snap-channel": ""})
+    await cloudflared_charm.set_config({"charmed-cloudflared-snap-channel": "latest/edge"})
     await model.wait_for_idle()
     _, snap_list, _ = await ops_test.juju("exec", "--unit", "chrony/0", "--", "snap", "list")
     assert "charmed-cloudflared_" in snap_list

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -92,6 +92,21 @@ async def test_cloudflared_route_integration(
     wait_for_tunnel_healthy(cloudflare_api, tunnel_token_2)
 
 
+async def test_update_snap_channel(ops_test, model, cloudflared_charm):
+    """
+    arrange: deploy the cloudflared charm.
+    act: update the charmed-cloudflared-snap-channel charm configuration.
+    assume: cloudflared charm should refresh all charmed-cloudflared snap instances.
+    """
+    await cloudflared_charm.set_config({"charmed-cloudflared-snap-channel": ""})
+    await model.wait_for_idle()
+    _, snap_list, _ = await ops_test.juju("exec", "--unit", "chrony/0", "--", "snap", "list")
+    assert "charmed-cloudflared_" in snap_list
+    for line in snap_list.splitlines():
+        if "charmed-cloudflared_" in line:
+            assert "latest/edge" in line
+
+
 async def test_nameserver(
     ops_test,
     model,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Unit test fixtures."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # pylint: disable=protected-access,too-many-arguments,too-many-positional-arguments

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]

--- a/tox.ini
+++ b/tox.ini
@@ -110,7 +110,7 @@ deps =
     juju==3.5.2.1
     pytest
     pytest-asyncio
-    pip
+    pytest-operator
     requests
     -r{toxinidir}/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -110,7 +110,7 @@ deps =
     juju==3.5.2.1
     pytest
     pytest-asyncio
-    pytest-operator
+    pip
     requests
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add a charm config `charmed-cloudflared-snap-channel` to select the snap channel for the installed `charmed-cloudflared`.
Also, copy `ca-certificates.crt` into the snap's directory. This is not absolute necessary but can suppress some warnings from cloudflared.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
