### PR TITLE
Accept juju-*-proxy model configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -151,12 +151,9 @@ class CloudflaredCharm(ops.CharmBase):
         http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
         https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
         no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
-        if http_proxy:
-            config["http-proxy"] = http_proxy
-        if https_proxy:
-            config["https-proxy"] = https_proxy
-        if no_proxy:
-            config["no-proxy"] = no_proxy
+        config["http-proxy"] = http_proxy or ""
+        config["https-proxy"] = https_proxy or ""
+        config["no-proxy"] = no_proxy or ""
         return config
 
     def _subprocess_run(self, cmd: list[str]) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,13 +147,11 @@ class CloudflaredCharm(ops.CharmBase):
         Returns:
             A dictionary of HTTP proxy related configurations.
         """
-        config = {}
-        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
-        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
-        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
-        config["http-proxy"] = http_proxy or ""
-        config["https-proxy"] = https_proxy or ""
-        config["no-proxy"] = no_proxy or ""
+        config = {
+            "http-proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "https-proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "no-proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+        }
         return config
 
     def _subprocess_run(self, cmd: list[str]) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,12 +147,11 @@ class CloudflaredCharm(ops.CharmBase):
         Returns:
             A dictionary of HTTP proxy related configurations.
         """
-        config = {
+        return {
             "http-proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
             "https-proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
             "no-proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
-        return config
 
     def _subprocess_run(self, cmd: list[str]) -> None:
         """Run a subprocess command.

--- a/src/charm.py
+++ b/src/charm.py
@@ -130,16 +130,8 @@ class CloudflaredCharm(ops.CharmBase):
             config = {
                 "tunnel-token": tunnel_spec.tunnel_token,
                 "metrics-port": metrics_ports[instance],
+                **self._proxy_config(),
             }
-            http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
-            https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
-            no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
-            if http_proxy:
-                config["http-proxy"] = http_proxy
-            if https_proxy:
-                config["https-proxy"] = https_proxy
-            if no_proxy:
-                config["no-proxy"] = no_proxy
             if all(charmed_cloudflared.get(key) == str(value) for key, value in config.items()):
                 continue
             logger.info("configuring charmed-cloudflared instance: %s", instance)
@@ -148,6 +140,24 @@ class CloudflaredCharm(ops.CharmBase):
             charmed_cloudflared.stop()
             charmed_cloudflared.start(enable=True)
         self.unit.status = ops.ActiveStatus()
+
+    def _proxy_config(self) -> dict[str, str]:
+        """Get HTTP proxy related configurations from the juju model configuration.
+
+        Returns:
+            A dictionary of HTTP proxy related configurations.
+        """
+        config = {}
+        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+        if http_proxy:
+            config["http-proxy"] = http_proxy
+        if https_proxy:
+            config["https-proxy"] = https_proxy
+        if no_proxy:
+            config["no-proxy"] = no_proxy
+        return config
 
     def _subprocess_run(self, cmd: list[str]) -> None:
         """Run a subprocess command.

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@
 """Cloudflared charm service."""
 
 import logging
+import os
 import pathlib
 import re
 import subprocess  # nosec
@@ -130,6 +131,15 @@ class CloudflaredCharm(ops.CharmBase):
                 "tunnel-token": tunnel_spec.tunnel_token,
                 "metrics-port": metrics_ports[instance],
             }
+            http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+            https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+            no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+            if http_proxy:
+                config["http-proxy"] = http_proxy
+            if https_proxy:
+                config["https-proxy"] = https_proxy
+            if no_proxy:
+                config["no-proxy"] = no_proxy
             if all(charmed_cloudflared.get(key) == str(value) for key, value in config.items()):
                 continue
             logger.info("configuring charmed-cloudflared instance: %s", instance)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Accepts `juju-http-proxy`, `juju-https-proxy`, and `juju-no-proxy` Juju model configurations for setting the HTTP proxy for `cloudflared`.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
