### PR TITLE
feat/ISD-3456: Adding custom wordlist for vale check. 

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,1 @@
+cloudflared


### PR DESCRIPTION


Applicable ticket: ISD-3456

### Overview

Just adding a custom wordlist. There really isn't anything else to fix. Vale only complains about the word `cloudflared`

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
